### PR TITLE
Fix I2Pd browser link

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 							<a href="https://github.com/PurpleI2P/i2pd-android/releases/latest"
 								data-l10n-id="header-dl-android" target="_blank">
 									Android app</a>
-							<a href="https://github.com/PurpleI2P/i2pdbrowser/releases/latest"
+							<a href="https://github.com/PurpleI2P/i2pdbrowser/"
 								data-l10n-id="header-dl-browser" target="_blank">
 									I2PdBrowser bundle</a>
 						</p>


### PR DESCRIPTION
The previous link took people to the releases page of the I2Pd Browser repository, which makes people think that it is through there that they can get the latest version of the browser, which is not true, as the `README` of the repository itself says in a note.